### PR TITLE
Add ERROR_NAMES constant

### DIFF
--- a/src/Constraint/DomainNameRegistrable.php
+++ b/src/Constraint/DomainNameRegistrable.php
@@ -34,6 +34,13 @@ final class DomainNameRegistrable extends Constraint
         self::PRIVATE_SUFFIX => 'PRIVATE_SUFFIX',
     ];
 
+    protected const ERROR_NAMES = [
+        self::INVALID_SYNTAX => 'INVALID_SYNTAX',
+        self::NOT_REGISTRABLE => 'NOT_REGISTRABLE',
+        self::REGISTRABLE_LENGTH_EXCEEDED => 'REGISTRABLE_LENGTH_EXCEEDED',
+        self::PRIVATE_SUFFIX => 'PRIVATE_SUFFIX',
+    ];
+
     /**
      * @param array<string, mixed>    $options
      * @param array<int, string>|null $groups

--- a/src/Constraint/DomainNameSuffix.php
+++ b/src/Constraint/DomainNameSuffix.php
@@ -34,6 +34,13 @@ final class DomainNameSuffix extends Constraint
         self::ICANN_UNKNOWN => 'ICANN_UNKNOWN',
     ];
 
+    protected const ERROR_NAMES = [
+        self::INVALID_SYNTAX => 'INVALID_SYNTAX',
+        self::UNKNOWN_SUFFIX => 'UNKNOWN_SUFFIX',
+        self::RESERVED_TLD_USED => 'RESERVED_TLD_USED',
+        self::ICANN_UNKNOWN => 'ICANN_UNKNOWN',
+    ];
+
     /**
      * @param array<string, mixed>    $options
      * @param array<int, string>|null $groups


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

Symfony 7 uses a variable while Symfony 8 uses a constant.
